### PR TITLE
`quit => doAssert` to show backtrace + relevant context + exception friendly

### DIFF
--- a/nimterop/git.nim
+++ b/nimterop/git.nim
@@ -19,10 +19,8 @@ proc execAction*(cmd: string, nostderr=false): string =
     else:
       (result, ret) = execCmdEx(ccmd)
   if ret != 0:
-    echo "Command failed: " & $ret
-    echo ccmd
-    echo result
-    quit(1)
+    let msg = "Command failed: " & $ret & "\nccmd: " & ccmd & "\nresult:\n" & result
+    doAssert false, msg
 
 proc extractZip*(zipfile, outdir: string) =
   var cmd = "unzip -o $#"

--- a/nimterop/lisp.nim
+++ b/nimterop/lisp.nim
@@ -25,13 +25,11 @@ proc tokenize(tree: string) =
 
 proc readFromTokens(): ref Ast =
   if idx == gTokens.len:
-    echo "Bad AST"
-    quit(1)
+    doAssert false, "Bad AST " & $(idx: idx)
 
   if gTokens[idx] == "(":
     if gTokens.len - idx < 2:
-      echo "Corrupt AST"
-      quit(1)
+      doAssert false, "Corrupt AST " & $(gTokensLen: gTokens.len, idx: idx)
     if gTokens[idx+1] != "comment":
       result = new(Ast)
       (result.name, result.kind, result.recursive) = gTokens[idx+1].getNameKind()
@@ -44,8 +42,7 @@ proc readFromTokens(): ref Ast =
       if not res.isNil():
         result.children.add(res)
   elif gTokens[idx] == ")":
-    echo "Poor AST"
-    quit(1)
+    doAssert false, "Poor AST " & $(idx: idx)
 
   idx += 1
 


### PR DESCRIPTION
* see: [quit considered evil: bypasses `defer` and `try/catch/finally` which might do important cleanups - Nim forum](https://forum.nim-lang.org/t/4042)
* assert messages should go in 1 line (eg: `doAssert foo, msg` instead of `echo msg1; echo msg2; doAssert foo, msg3`) because the former can give intermingled outputs in multithreaded/mult-process applications, whereas the latter will guarantee a lock on stdout until the msg is printed out